### PR TITLE
Add MetaReview - open-source meta-analysis platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Tools ([edit to add one](https://github.com/INRIA/awesome-open-science-software/
 * [Depsy](http://depsy.org/) helps build the software-intensive science of the future by promoting credit for software as a fundamental building block of science. 
 * [CodeMeta](https://codemeta.github.io/) The CodeMeta project proposes a way to have structured metadata for research software.
 * [code-ini](https://github.com/gramian/code-ini) Code meta data via .ini files
+* [MetaReview](https://metareview-8c1.pages.dev/) Free, open-source online platform for statistical meta-analysis in medical research. Features forest plots, funnel plots, GRADE assessment, and automated report generation. ([GitHub](https://github.com/TerryFYL/metareview))
 
 Software as Research Object
 ---------------------------


### PR DESCRIPTION
Add [MetaReview](https://metareview-8c1.pages.dev/) to the Tools section.

MetaReview is a free, open-source web-based platform for conducting systematic reviews and meta-analyses in medical research. It promotes open science by:
- Providing free access to professional-grade statistical analysis tools
- Supporting reproducible research with shareable analysis links and structured data export (JSON/CSV)
- Integrating with PubMed for transparent literature discovery
- Generating PRISMA-compliant reports

Built with React + TypeScript + D3.js, deployed on Cloudflare Pages.

**GitHub:** https://github.com/TerryFYL/metareview
**Live:** https://metareview-8c1.pages.dev/