### PR TITLE
Add CiteMe to Software Support for Open Science

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ Software Support for Open Science
 * [LabPal](https://liflab.github.io/labpal) is a Java library that allows you to design, control, process and package experiments that are run on a computer, and to streamline the integration of results within a research paper.
 * [OpenChrom](https://openchrom.net) is a cross-platform chromatography data analysis tool with support for both proprietary vendor formats and open alternatives to publish as FAIR data.
 * [Calkit](https://github.com/calkit/calkit) is a project framework and toolkit to help researchers work reproducibly.
+* [CiteMe](https://citeme.app) is an AI-powered academic citation generator. It searches 11+ databases (OpenAlex, PubMed, Semantic Scholar, CrossRef) and formats references in 40+ citation styles (APA, ABNT, MLA, Chicago). Available as web app, Chrome extension, Google Docs add-on, and Word add-in.
 
 Courses
 -------


### PR DESCRIPTION
## Summary

Adds [CiteMe](https://citeme.app) to the **Software Support for Open Science** section.

CiteMe is an AI-powered academic citation generator that searches 11+ databases (OpenAlex, PubMed, Semantic Scholar, CrossRef) and formats references in 40+ citation styles (APA, ABNT, MLA, Chicago). It is available as a web app, Chrome extension, Google Docs add-on, and Word add-in.

## Changes

- Added one bullet point entry for CiteMe in the "Software Support for Open Science" section, following the existing format and alphabetical ordering.