### PR TITLE
Add BGPT MCP to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Tools ([edit to add one](https://github.com/INRIA/awesome-open-science-software/
 * [CodeMeta](https://codemeta.github.io/) The CodeMeta project proposes a way to have structured metadata for research software.
 * [code-ini](https://github.com/gramian/code-ini) Code meta data via .ini files
 * [MetaReview](https://metareview-8c1.pages.dev/) Free, open-source online platform for statistical meta-analysis in medical research. Features forest plots, funnel plots, GRADE assessment, and automated report generation. ([GitHub](https://github.com/TerryFYL/metareview))
+* [BGPT MCP](https://github.com/connerlambden/bgpt-mcp) Remote MCP server for searching scientific papers with structured experimental data from full-text studies. SSE + Streamable HTTP endpoints. (`npx bgpt-mcp`)
 
 Software as Research Object
 ---------------------------


### PR DESCRIPTION
Adds [BGPT MCP](https://github.com/connerlambden/bgpt-mcp) — remote MCP server for searching scientific papers with structured experimental data from full-text studies.

- SSE + Streamable HTTP endpoints
- Tool: `search_papers`
- npm: `npx bgpt-mcp`