### PR TITLE
Add PRML / falsify to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Tools ([edit to add one](https://github.com/INRIA/awesome-open-science-software/
 * [code-ini](https://github.com/gramian/code-ini) Code meta data via .ini files
 * [MetaReview](https://metareview-8c1.pages.dev/) Free, open-source online platform for statistical meta-analysis in medical research. Features forest plots, funnel plots, GRADE assessment, and automated report generation. ([GitHub](https://github.com/TerryFYL/metareview))
 * [BGPT MCP](https://github.com/connerlambden/bgpt-mcp) Remote MCP server for searching scientific papers with structured experimental data from full-text studies. SSE + Streamable HTTP endpoints. (`npx bgpt-mcp`)
+* [PRML / falsify](https://spec.falsify.dev/v0.1) Pre-Registered ML Manifest: an open specification (CC BY 4.0) for committing a machine learning evaluation claim — metric, comparator, threshold, dataset hash, seed, producer identity — to a SHA-256 hash before the experiment runs. Any retroactive edit changes the hash. Four byte-equivalent reference implementations in Python, JavaScript, Go, and Rust across 20 conformance vectors. JSON Schema in the [SchemaStore catalog](https://www.schemastore.org/). Zenodo DOI [10.5281/zenodo.20177839](https://doi.org/10.5281/zenodo.20177839); [JOSS paper](https://github.com/studio-11-co/falsify/tree/main/paper/joss) in preparation.
 
 Software as Research Object
 ---------------------------


### PR DESCRIPTION
PRML (Pre-Registered ML Manifest) is an open specification (CC BY 4.0) for committing a machine learning evaluation claim — metric, comparator, threshold, dataset hash, seed, producer identity — to a SHA-256 hash before the experiment runs. Any retroactive edit changes the hash, making post-hoc threshold tuning detectable by any third party.

Adding under **Tools** (Software as Experimental Tool) since it sits alongside CodeMeta and Depsy: tooling that helps make computational science more transparent and verifiable.

Why it fits this list:
- CC BY 4.0 spec, MIT code, [Zenodo DOI 10.5281/zenodo.20177839](https://doi.org/10.5281/zenodo.20177839), archived in Software Heritage
- Four byte-equivalent reference implementations (Python, JavaScript, Go, Rust) across 20 conformance vectors — every implementation passes every vector byte-for-byte
- JSON Schema merged into the [SchemaStore catalog](https://www.schemastore.org/) (autocomplete in VS Code / JetBrains / Helix / Zed / Cursor)
- [JOSS paper](https://github.com/studio-11-co/falsify/tree/main/paper/joss) in preparation (6-month repository age requirement reached November 2026)

The spec is deliberately minimal: an eight-field YAML manifest, deterministic canonicalisation, no runtime infrastructure required. Spec §8.1 explicitly names what it does not solve (selective non-publication, execution integrity) and defers those to companion mechanisms.

Single-line addition. Open to revisions on framing or placement.